### PR TITLE
readme: update database creation detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can run your own Standard File server, and use it with any SF compatible cli
 
 	```
 	bundle install
-	rails db:migrate
+	rails db:create db:migrate
 	```
 
 4. Start the server:


### PR DESCRIPTION
I noticed that `db:create` is missing in the readme. Just making a minor update to ensure that you create the database before you migrate.