### PR TITLE
Show message when user accesses server

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<title> Standard File Server </title>
+		<style>
+			body {
+				padding-top: 20%;
+				text-align: center;
+				font-family: sans-serif;
+			}
+			p {
+				width: 80%;
+				margin-right: auto;
+				margin-left: auto;
+				font-size: x-large;
+			}
+		</style>
+	</head>
+	
+	<body>
+		<h1> Hi! You are not supposed to be here. </h1>
+
+		<p> You might be looking for the <a href="https://app.standardnotes.org"> Standard Notes Web App</a> or the main <a href="https://standardnotes.org"> Standard Notes Website</a>. </p>
+
+	</body>
+</html>
+		


### PR DESCRIPTION
fix https://github.com/standardfile/ruby-server/issues/13

If someone accesses the server via the browser we let them
know that there is nothing here and direct them to either the web app
or the main Standard Notes website.

Adding screenshot for posterity :) 

![landing page](https://cloud.githubusercontent.com/assets/7981032/22098501/73efd138-dddb-11e6-87c1-52cb4f9f8f22.png)
