### PR TITLE
Perform cleanup after installing packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM ubuntu:latest
 
-RUN apt-get update; apt-get install -y git build-essential ruby-dev ruby-rails libz-dev libmysqlclient-dev
+RUN DEBIAN_FRONTEND=noninteractive \
+    apt-get -y update && \
+	apt-get -y install git build-essential ruby-dev ruby-rails libz-dev libmysqlclient-dev && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    apt-get autoremove -y && \
+    apt-get clean
 
 ADD ./ /data/src/
 


### PR DESCRIPTION
Due to how Docker layers work, we should clean up the unneeded package
cache, otherwise this will add a large amount of bloat to our image.