### PR TITLE
Make dropbox optional requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ Database username.
 
 Database password.
 
+#### Optional environment variables if you want to use Dropbox
+
+**HOST**
+
+Server url
+
+**DROPBOX_CLIENT_ID**
+
+Dropbox client id
+
+**DROPBOX_CLIENT_SECRET**
+
+Dropbox client secret
+
 ## Contributing
 Contributions are encouraged and welcome. Currently outstanding items:
 

--- a/config/initializers/dropbox_ext.rb
+++ b/config/initializers/dropbox_ext.rb
@@ -1,3 +1,5 @@
-DropboxExt.mount_url = ENV["HOST"] + "/ext/dropbox"
-DropboxExt.db_client_id = ENV["DROPBOX_CLIENT_ID"]
-DropboxExt.db_client_secret = ENV["DROPBOX_CLIENT_SECRET"]
+if ENV["HOST"] && ENV["DROPBOX_CLIENT_ID"] && ENV["DROPBOX_CLIENT_SECRET"]
+  DropboxExt.mount_url = ENV["HOST"] + "/ext/dropbox"
+  DropboxExt.db_client_id = ENV["DROPBOX_CLIENT_ID"]
+  DropboxExt.db_client_secret = ENV["DROPBOX_CLIENT_SECRET"]
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,22 +18,22 @@ ActiveRecord::Schema.define(version: 20170205182304) do
     t.string   "enc_item_key"
     t.string   "auth_hash"
     t.string   "user_uuid"
+    t.boolean  "deleted",                       default: false
     t.datetime "created_at",                                    null: false
     t.datetime "updated_at",                                    null: false
-    t.boolean  "deleted",                       default: false
     t.index ["updated_at"], name: "index_items_on_updated_at", using: :btree
     t.index ["user_uuid", "content_type"], name: "index_items_on_user_uuid_and_content_type", using: :btree
     t.index ["user_uuid"], name: "index_items_on_user_uuid", using: :btree
   end
 
   create_table "users", primary_key: "uuid", id: :string, limit: 36, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "encrypted_password", default: "", null: false
+    t.string   "email"
     t.string   "pw_func"
     t.string   "pw_alg"
     t.integer  "pw_cost"
     t.integer  "pw_key_size"
     t.string   "pw_nonce"
-    t.string   "email"
+    t.string   "encrypted_password", default: "", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["email"], name: "index_users_on_email", using: :btree


### PR DESCRIPTION
# Background

Since sf-dropbox-ext gem was added, people without dropbox related environment were not able to run the server nor run migrations.

You will see error like this.

```
SyntaxError: /home/jason/projects/rails/ruby-server/config/initializers/dropbox_ext.rb:1: Invalid return
/home/jason/projects/rails/ruby-server/config/initializers/dropbox_ext.rb
```
# Changes

- Updated readme about adding in optional environment variables for dropbox
- Updated dropbox_ext initializer so dropbox variables are not requirements

