### PR TITLE
upgraded docker-compose mysql version to 5.7.17

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,6 @@ services:
     ports:
       - "3000:3000"
   db:
-    image: mysql:5.5.53
+    image: mysql:5.7.17
     environment:
       - MYSQL_ROOT_PASSWORD=secret123


### PR DESCRIPTION
I see the following error message when I tried to run `docker-compose up` with the original configuration. It seems like `mysql2` gem doesn't work quite well with mysql 5.5.53. (the line is from the db:migrate task)
```
app_1  | Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '(6) NOT NULL' at line 1: ALTER TABLE `items` CHANGE `created_at` `created_at` datetime(6) NOT NULL
```
Upgrading mysql to 5.7.17 seems to have solved the problem.